### PR TITLE
Filter changes at the change source level

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -24,6 +24,7 @@ from buildbot.steps.source.gerrit import Gerrit
 from buildbot.steps.slave import RemoveDirectory
 from buildbot.changes.filter import ChangeFilter
 from buildbot.changes.gerritchangesource import GerritChangeFilter
+from buildbot.changes.gerritchangesource import GerritChangeSource
 from buildbot.buildslave import BuildSlave
 from buildbot.status.results import SUCCESS, WARNINGS, FAILURE, EXCEPTION
 from buildbot import config
@@ -85,7 +86,7 @@ def should_watch_branch (branch):
     else:
         return False
 
-from buildbot.changes.gitpoller import GitPoller
+#from buildbot.changes.gitpoller import GitPoller
 c['change_source'] = []
 #c['change_source'].append(GitPoller(
 #        repourl = main_repo_url,
@@ -93,8 +94,16 @@ c['change_source'] = []
 #	branches = should_watch_branch,
 #	pollinterval = 30))
 
-from buildbot.changes.gerritchangesource import GerritChangeSource
-c['change_source'].append(GerritChangeSource(gerrit_server, gerrit_user, handled_events=("patchset-created",)))
+class FilteringGerritChangeSource(GerritChangeSource):
+    def eventReceived_patchset_created(self, properties, event):
+        if event['change']['project'] == 'toside/binutils-gdb':
+            self.addChangeFromEvent(properties, event)
+
+c['change_source'].append(
+    FilteringGerritChangeSource(gerrit_server,
+                                gerrit_user,
+                                handled_events=("patchset-created",)))
+
 # 'status' is a list of Status Targets. The results of each build will be
 # pushed to these targets. buildbot/status/*.py has a variety to choose from,
 # including web pages, email senders, and IRC bots.


### PR DESCRIPTION
So buildbot doesn't get polluted with _all_ patchset created events from
Gerrit.
